### PR TITLE
Added support for youtube urls that start with "youtu.be"

### DIFF
--- a/micawber/providers.py
+++ b/micawber/providers.py
@@ -113,7 +113,7 @@ def bootstrap_basic(cache=None):
     # complements of oembed.com#section7
     pr = ProviderRegistry(cache)
     pr.register('http://\S*?flickr.com/\S*', Provider('http://www.flickr.com/services/oembed/'))
-    pr.register('https?://\S*.youtu(\.be|be\.com)/watch\S*', Provider('http://www.youtube.com/oembed'))
+    pr.register('https?://(\S*.)?youtu(\.be/|be\.com/watch)\S*', Provider('http://www.youtube.com/oembed'))
     pr.register('http://\S*.viddler.com/\S*', Provider('http://lab.viddler.com/services/oembed/'))
     pr.register('http://qik.com/video/\S*', Provider('http://qik.com/api/oembed.json'))
     pr.register('http://\S*.revision3.com/\S*', Provider('http://revision3.com/api/oembed/'))


### PR DESCRIPTION
Urls that started with youtu.be got an ProviderException.
I loosened up the regex for the youtube Provider so that these urls are also recognized as youtube urls.

In the meanwhile users can work around it with this:

```
import micawber
from micawber.providers import Provider

url = 'http://youtu.be/VpmOTGungnA'
pr = micawber.bootstrap_basic()
pr.register('https?://(\S*.)?youtu(\.be/|be\.com/watch)\S*', Provider('http://www.youtube.com/oembed'))
metadata = pr.request(url)
```
