### PR TITLE
Add more OEmbed providers, and support for noembed.com

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -105,6 +105,23 @@ Providers
         pr = bootstrap_embedly(key='my-embedly-key')
         pr.request('http://www.youtube.com/watch?v=54XHDUOHuzU')
 
+.. py:function:: bootstrap_noembed([cache=None, [**kwargs]])
+
+    Create a :py:class:`ProviderRegistry` and register as many providers as
+    are supported by `noembed.com <http://noembed.com>`_.  Valid services are
+    fetched from http://noembed.com/providers and parsed then registered.
+
+    :param cache: an object that implements simple ``get`` and ``set``
+    :param kwargs: any default keyword arguments to use with providers, useful for
+        passing the ``nowrap`` option to noembed.
+    :rtype: a ProviderRegistry with support for noembed
+
+    .. code-block:: python
+
+        # if you have an API key, you can specify that here
+        pr = bootstrap_noembed(nowrap=1)
+        pr.request('http://www.youtube.com/watch?v=54XHDUOHuzU')
+
 Parsers
 -------
 

--- a/micawber/providers.py
+++ b/micawber/providers.py
@@ -206,3 +206,22 @@ def bootstrap_embedly(cache=None, **params):
         for regex in provider_meta['regex']:
             pr.register(regex, Provider(endpoint, **params))
     return pr
+
+
+def bootstrap_noembed(cache=None, **params):
+    endpoint = 'http://noembed.com/embed'
+    schema_url = 'http://noembed.com/providers'
+
+    pr = ProviderRegistry(cache)
+
+    # fetch the schema
+    resp = urllib2.urlopen(schema_url)
+    contents = resp.read()
+    resp.close()
+
+    json_data = json.loads(contents)
+
+    for provider_meta in json_data:
+        for regex in provider_meta['patterns']:
+            pr.register(regex, Provider(endpoint, **params))
+    return pr


### PR DESCRIPTION
This pull adds support for:
- flic.kr
- gist.github.com
- mobypicture / moby.to
- polldaddy,
- scribd.com
- slidesha.re
- speakerdesk
- yfrog

These services were found via the WordPress 3.5.1 source code, embedly provider list, and some educated guesses.

The second commit add support for http://noembed.com, a free service which - like embed.ly - also supports several popular sites that don't support oembed themselves.

I hope you can merge this patch, so these improvements can find their way into a new micawber release :)
