### PR TITLE
html_parse() unescapes html entities

### DIFF
--- a/micawber/parsers.py
+++ b/micawber/parsers.py
@@ -129,7 +129,7 @@ def parse_html(html, providers, urlize_all=True, handler=full_handler, block_han
 
             url_unescaped = url.string
             replacement = parse_text_full(url_unescaped, providers, urlize_all, url_handler, **params)
-            url.replaceWith(BeautifulSoup(replacement))
+            url.replaceWith(replacement)
 
     return unicode(soup)
 


### PR DESCRIPTION
```
>>> parse_html('&lt;img src="http://www.youtube.com/embed/_MbtUZSXQR4" /img&gt;',       ProviderRegistry(), urlize_all=False)
u'<img src="http://www.youtube.com/embed/_MbtUZSXQR4" />'
```

As you can see, I passed in escaped html, and now it is unescaped
I found out that it replaces escaped text with unescaped in this line:

```
 url.replaceWith(BeautifulSoup(replacement))
```

If we won't wrap `replacement` with `BeautifulSoup`, `replaceWith()` method automatically escapes the string while modifing the original soup.
I really don't see the point why the `replacement` is wrapped by `BeautifulSoup` call.
