### PR TITLE
Update runtests.py for Django 1.5 compatibility.

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -23,7 +23,11 @@ def run_django_tests():
     from django.conf import settings
     if not settings.configured:
         settings.configure(
-            DATABASE_ENGINE='sqlite3',
+            DATABASES={
+                'default': {
+                    'ENGINE': 'django.db.backends.sqlite3',
+                    },
+                },
             SITE_ID=1,
             INSTALLED_APPS=[
                 'django.contrib.auth',
@@ -40,11 +44,12 @@ def run_django_tests():
         settings.MICAWBER_PROVIDERS = providers
         settings.MICAWBER_TEMPLATE_EXTENSIONS = extensions
 
-    from django.test.simple import run_tests
+    from django.test.simple import DjangoTestSuiteRunner
     parent = os.path.dirname(os.path.abspath(__file__))
     sys.path.insert(0, parent)
-    return run_tests(['mcdjango_tests'], verbosity=1, interactive=True)
-        
+    return DjangoTestSuiteRunner(
+        verbosity=1, interactive=True).run_tests(['mcdjango_tests'])
+
 
 def runtests(*test_args):
     print "Running micawber tests"


### PR DESCRIPTION
The Django integration tests were failing to run against Django 1.5 because they used test API that's been deprecated since Django 1.3 and was removed in 1.5, and DATABASES setting syntax that's been deprecated I think since 1.2?

I updated both of these and the tests now run and pass against Django 1.5.1, 1.4.5, and 1.3.7. This pull request means the tests will no longer run against Django 1.2 or earlier (not that I tested whether they did previously).
