### PR TITLE
Don't crash if title not provided

### DIFF
--- a/micawber/parsers.py
+++ b/micawber/parsers.py
@@ -33,6 +33,7 @@ skip_elements = set(['a', 'pre', 'code'])
 
 
 def full_handler(url, response_data, **params):
+    response_data.setdefault('title', response_data.get('url', ''))
     if response_data['type'] == 'link':
         return '<a href="%(url)s" title="%(title)s">%(title)s</a>' % response_data
     elif response_data['type'] == 'photo':
@@ -41,6 +42,7 @@ def full_handler(url, response_data, **params):
         return response_data['html']
 
 def inline_handler(url, response_data, **params):
+    response_data.setdefault('title', response_data.get('url', ''))
     return '<a href="%(url)s" title="%(title)s">%(title)s</a>' % response_data
 
 def urlize(url):

--- a/micawber/test_utils.py
+++ b/micawber/test_utils.py
@@ -29,6 +29,9 @@ class TestProvider(Provider):
 
         # with param
         'link?format=json&url=http%3A%2F%2Flink-test1&width=100': {'title': 'test1', 'type': 'link', 'width': 99},
+
+        # missing title
+        'photo?format=json&url=http%3A%2F%2Fphoto-notitle1': {'url': 'notitle1.jpg', 'type': 'photo'},
     }
 
     def fetch(self, url):
@@ -54,8 +57,10 @@ class BaseTestCase(unittest.TestCase):
         self.full_pairs = {
             'http://link-test1': '<a href="http://link-test1" title="test1">test1</a>',
             'http://photo-test2': '<a href="test2.jpg" title="ptest2"><img alt="ptest2" src="test2.jpg" /></a>',
+            'http://photo-test2': '<a href="test2.jpg" title="ptest2"><img alt="ptest2" src="test2.jpg" /></a>',
             'http://video-test1': '<test1>video</test1>',
             'http://rich-test2': '<test2>rich</test2>',
+            'http://photo-notitle1': '<a href="notitle1.jpg" title="notitle1.jpg"><img alt="notitle1.jpg" src="notitle1.jpg" /></a>',
         }
 
         self.inline_pairs = {
@@ -63,6 +68,7 @@ class BaseTestCase(unittest.TestCase):
             'http://photo-test2': '<a href="test2.jpg" title="ptest2">ptest2</a>',
             'http://video-test1': '<a href="http://video-test1" title="vtest1">vtest1</a>',
             'http://rich-test2': '<a href="http://rich-test2" title="rtest2">rtest2</a>',
+            'http://photo-notitle1': '<a href="notitle1.jpg" title="notitle1.jpg">notitle1.jpg</a>',
         }
 
         self.data_pairs = {
@@ -70,6 +76,7 @@ class BaseTestCase(unittest.TestCase):
             'http://photo-test2': {'title': 'ptest2', 'url': 'test2.jpg', 'type': 'photo'},
             'http://video-test1': {'title': 'vtest1', 'html': '<test1>video</test1>', 'type': 'video'},
             'http://rich-test2': {'title': 'rtest2', 'html': '<test2>rich</test2>', 'type': 'rich'},
+            'http://photo-notitle1': {'url': 'notitle1.jpg', 'type': 'photo'},
         }
 
     def assertCached(self, url, data, **params):


### PR DESCRIPTION
Some providers don't seem to send back a title and that causes a KeyError.

We ran into this while using photobucket
