### PR TITLE
added JSON error handling for nasty providers

### DIFF
--- a/micawber/exceptions.py
+++ b/micawber/exceptions.py
@@ -3,3 +3,6 @@ class ProviderException(Exception):
 
 class ProviderNotFoundException(ProviderException):
     pass
+
+class ProviderBadResponseException(ProviderException):
+    pass

--- a/micawber/providers.py
+++ b/micawber/providers.py
@@ -8,7 +8,7 @@ try:
 except ImportError:
     import json
 
-from micawber.exceptions import ProviderException, ProviderNotFoundException
+from micawber.exceptions import ProviderException, ProviderNotFoundException, ProviderBadResponseException
 
 
 class Provider(object):
@@ -60,7 +60,7 @@ class Provider(object):
             ## or sometimes they are asses and will return "This video can not be embedded" as plaintext
             json_data = json.loads(response)
         except:
-            json_data = { 'micawber-error' : True, 'micawber-response' : response }
+            raise ProviderBadResponseException(response)
         if 'url' not in json_data:
             json_data['url'] = url
         if 'title' not in json_data:


### PR DESCRIPTION
I recently came across an error with this page :
- http://www.dailymotion.com/video/x16m9xy_shareholder-to-yahoo-ceo-marissa-mayer-you-look-attractive_news

dailymotion should be returning an oEmbed packet, but instead returns the text "This video can not be embedded".  i stress "text".  it is not in json.  it is just text.

this breaks the json load.

my proposed patch wraps the json load in a try/except block.

if an exception occurs (any, i'm not picky, though ValueError is trigged by this particular load ), it creates a new dict for the json data:

```
json_data = { 'micawber-error' : True, 'micawber-response' : response }
```

this allows people to easily inspect.

the url & title will be populated by the existing block.

an alternative would be to raise a ProviderException , or create a new exception:

```
class ProviderBadResponseException(ProviderException):
    pass
```

If that's the route you prefer, I would suggest stuffing the actual response into the exception .

I'll also add that the micawber demo on appsport will work on this particular url.  it just seems to break on my machines.  maybe this provider doesn't like me.
