### PR TITLE
fixed https reg exp for flicker

### DIFF
--- a/micawber/providers.py
+++ b/micawber/providers.py
@@ -150,8 +150,8 @@ def bootstrap_basic(cache=None):
     pr.register('https?://(www\.)?dailymotion\.com/\S+', Provider('http://www.dailymotion.com/services/oembed'))
 
     # f
-    pr.register('http://\S*?flickr.com/\S+', Provider('http://www.flickr.com/services/oembed/'))
-    pr.register('http://flic\.kr/\S*', Provider('http://www.flickr.com/services/oembed/'))
+    pr.register('https?://\S*?flickr.com/\S+', Provider('http://www.flickr.com/services/oembed/'))
+    pr.register('https?://flic\.kr/\S*', Provider('http://www.flickr.com/services/oembed/'))
     pr.register('https?://(www\.)?funnyordie\.com/videos/\S+', Provider('http://www.funnyordie.com/oembed'))
 
     # g


### PR DESCRIPTION
flicker now expose shortened url with https and the regexp of the provider do not match
