### PR TITLE
Catch AttributeError when importing simplejson.

### DIFF
--- a/micawber/providers.py
+++ b/micawber/providers.py
@@ -12,7 +12,7 @@ from .compat import urlopen
 try:
     import simplejson as json
     InvalidJson = json.JSONDecodeError
-except ImportError:
+except (ImportError, AttributeError) as e:
     import json
     InvalidJson = ValueError
 


### PR DESCRIPTION
I needed this fix for django 1.6.10 on python 2.6. I'm really not sure why the simplejson import worked, but it did seem to import without an import error and then it didn't have the `JSONDecodeError` attribute. 