### PR TITLE
Support www for instagram urls

### DIFF
--- a/micawber/providers.py
+++ b/micawber/providers.py
@@ -175,7 +175,7 @@ def bootstrap_basic(cache=None, registry=None):
     # i
     pr.register('http://www.ifixit.com/Guide/View/\S+', Provider('http://www.ifixit.com/Embed'))
     pr.register('http://\S*imgur\.com/\S+', Provider('http://api.imgur.com/oembed')),
-    pr.register('https?://instagr(\.am|am\.com)/p/\S+', Provider('http://api.instagram.com/oembed'))
+    pr.register('https?://(www\.)?instagr(\.am|am\.com)/p/\S+', Provider('http://api.instagram.com/oembed'))
 
     # j
     pr.register('http://www.jest.com/(video|embed)/\S+', Provider('http://www.jest.com/oembed.json'))


### PR DESCRIPTION
Minor fix to the regex to support the provider record for Instagram

Instagram url's now start with a mandatory www subdomain. A link with http://instagram.com/p/:id/ now redirect to a https://www.instagram.com/p/:id/ url