### PR TITLE
Added support for FB public posts and videos using FB's developer documentation

### DIFF
--- a/micawber/providers.py
+++ b/micawber/providers.py
@@ -166,6 +166,20 @@ def bootstrap_basic(cache=None, registry=None):
     pr.register('https?://flic\.kr/\S*', Provider('https://www.flickr.com/services/oembed/'))
     pr.register('https?://(www\.)?funnyordie\.com/videos/\S+', Provider('http://www.funnyordie.com/oembed'))
 
+    # f - facebook posts
+    pr.register('https://www.facebook.com/[^\/]+/(posts|activity)/[^\/]+', Provider('https://www.facebook.com/plugins/post/oembed.json/'))
+    pr.register('https://www.facebook.com/[^\/]+/photos/[^\/]+/[^\/]+/\S+', Provider('https://www.facebook.com/plugins/post/oembed.json/'))
+    pr.register('https://www.facebook.com/photo.php\?fbid=\S+', Provider('https://www.facebook.com/plugins/post/oembed.json/'))
+    pr.register('https://www.facebook.com/photos/\S+', Provider('https://www.facebook.com/plugins/post/oembed.json/'))
+    pr.register('https://www.facebook.com/permalink.php\?story_fbid=\S+', Provider('https://www.facebook.com/plugins/post/oembed.json/'))
+    pr.register('https://www.facebook.com/media/set\?set=\S+', Provider('https://www.facebook.com/plugins/post/oembed.json/'))
+    pr.register('https://www.facebook.com/questions/\S+', Provider('https://www.facebook.com/plugins/post/oembed.json/'))
+    pr.register('https://www.facebook.com/notes/[^\/]+/[^\/]+/[^\/]+', Provider('https://www.facebook.com/plugins/post/oembed.json/'))
+
+    # f - facebook videos
+    pr.register('https://www.facebook.com/[^\/]+/videos/[^\/]+/', Provider('https://www.facebook.com/plugins/video/oembed.json/'))
+    pr.register('https://www.facebook.com/video.php?(id|v)=\S+', Provider('https://www.facebook.com/plugins/video/oembed.json/'))
+
     # g
     pr.register(r'https?://gist.github.com/\S*', Provider('https://github.com/api/oembed'))
 


### PR DESCRIPTION
For facebook at https://developers.facebook.com/docs/plugins/oembed-endpoints

Tested with urls
- https://www.facebook.com/SSRajamouli/photos/a.110306842412362.15991.110106192432427/1074721632637540/?type=3
- https://www.facebook.com/publicenemy/posts/1283615724996488
- https://www.facebook.com/shakira/photos/a.142708799559.109364.5027904559/10155214244304560/?type=3&permPage=1
- https://www.facebook.com/OpinionPolls/posts/1447334938641596
- https://www.facebook.com/youtube/videos/10155481607356754/?permPage=1