### PR TITLE
Add badges to README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,15 @@
+.. image:: https://img.shields.io/pypi/v/micawber.svg
+    :target: https://pypi.python.org/pypi/micawber
+
+.. image:: https://img.shields.io/pypi/l/micawber.svg
+    :target: https://pypi.python.org/pypi/micawber
+
+.. image:: https://img.shields.io/pypi/wheel/micawber.svg
+    :target: https://pypi.python.org/pypi/micawber
+
+.. image:: https://img.shields.io/pypi/pyversions/micawber.svg
+    :target: https://pypi.python.org/pypi/micawber
+
 .. image:: http://media.charlesleifer.com/blog/photos/micawber-logo.png
 
 .. image:: http://media.charlesleifer.com/blog/photos/micawber.jpg

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,7 @@ setup(
             '*/templates/*.html',
         ],
     },
+    license='mit',
     classifiers=[
         'Development Status :: 4 - Beta',
         'Environment :: Web Environment',


### PR DESCRIPTION
This adds a few badges to the `README.rst`, to make it obvious what the official PyPI package is, and a few other bits of information.

There's also a fix for the license badge, as soon as the next version is released on PyPI, the license badge shouldn't be "unknown" any more.

For the next version released on PyPI, upload a wheel package by running `python setup.py bdist_wheel && twine upload dist/*.wheel`