### PR TITLE
Fix PicleCache error on Python3

### DIFF
--- a/micawber/cache.py
+++ b/micawber/cache.py
@@ -26,14 +26,13 @@ class PickleCache(Cache):
     
     def load(self):
         if os.path.exists(self.filename):
-            with closing(open(self.filename)) as fh:
-                contents = fh.read()
-            return pickle.loads(contents)
+            with closing(open(self.filename, 'rb')) as fh:
+                return pickle.load(fh)
         return {}
 
     def save(self):
-        with closing(open(self.filename, 'w')) as fh:
-            fh.write(pickle.dumps(self._cache))
+        with closing(open(self.filename, 'wb')) as fh:
+            pickle.dump(self._cache, fh)
 
 
 if Redis:


### PR DESCRIPTION
On Python3, pickle.dump and load require byte stream.  For the example, run the following code

```
import micawber

cache = micawber.PickleCache()
providers = micawber.bootstrap_basic(cache)
providers.request('https://www.youtube.com/watch?v=e7zzdl8OXCU')
cache.save()
```

then the last line raises an exception:

> Traceback (most recent call last):
>   File "/home/mictest.py", line 6, in <module>
>     cache.save()
>   File "/usr/local/lib/python3.8/site-packages/micawber/cache.py", line 36, in save
>     fh.write(pickle.dumps(self._cache))
> TypeError: write() argument must be str, not bytes