### PR TITLE
Update the RedisCache's key_fn to actually only require one argument

### DIFF
--- a/micawber/cache.py
+++ b/micawber/cache.py
@@ -42,7 +42,7 @@ if Redis:
         """
         def __init__(self, namespace='micawber', timeout=None, **conn):
             self.namespace = namespace
-            self.key_fn = lambda self, k: '%s.%s' % (self.namespace, k)
+            self.key_fn = lambda k: '%s.%s' % (self.namespace, k)
             self.timeout = timeout
             self.conn = Redis(**conn)
 


### PR DESCRIPTION
I'm not 100% sure what's going on here. My first hunch was that there's a difference between Python 2 and 3's handling of assigned functions, but that doesn't seem to be the case. Certainly, `key_fn` doesn't act as a method but as a function even though it's assigned to a class (but on the instance, not on the class itself)

I didn't add tests because right now the tests do not depend on redis and I assume that you want to keep it that way.

Thanks!

```python
Python 3.10.6 (main, May 29 2023, 11:10:38) [GCC 11.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> class Thing:
...     def __init__(self):
...         self.fn = lambda hello: hello
...
>>> t = Thing()
>>> t.fn("hello")
'hello'
>>>
```
