### PR TITLE
fix: skip maps query params without equals

### DIFF
--- a/micawber/contrib/providers.py
+++ b/micawber/contrib/providers.py
@@ -42,6 +42,8 @@ class GoogleMapsProvider(Provider):
         map_params = ['output=embed']
 
         for param in url_params:
+            if '=' not in param:
+                continue
             k, v = param.split('=', 1)
             if k in self.valid_params:
                 map_params.append(param)

--- a/micawber/tests.py
+++ b/micawber/tests.py
@@ -669,5 +669,19 @@ class TestHTMLEntities(BaseTestCase):
             '&lt;foo&gt;</p>'))
 
 
+
+class GoogleMapsProviderTestCase(unittest.TestCase):
+    def test_query_param_without_equals(self):
+        from micawber.contrib.providers import GoogleMapsProvider
+        p = GoogleMapsProvider('')
+        # Flag-style query params (no '=') must not raise.
+        result = p.request('https://maps.google.com/maps?q')
+        self.assertEqual(result['type'], 'rich')
+        self.assertIn('output=embed', result['html'])
+        result = p.request('https://maps.google.com/maps?foo&q=Paris')
+        self.assertIn('q=Paris', result['html'])
+        self.assertNotIn('foo', result['html'].split('maps?')[1])
+
+
 if __name__ == '__main__':
     unittest.main(argv=sys.argv)


### PR DESCRIPTION
GoogleMapsProvider.request hits ValueError when query param without equals. This PR fixes the regression with a focused test covering the case.
