### PR TITLE
fix: reject non-object JSON in handle_response

### DIFF
--- a/micawber/providers.py
+++ b/micawber/providers.py
@@ -62,6 +62,10 @@ class Provider(object):
         except ValueError as exc:
             raise InvalidResponseException(str(exc)) from exc
 
+        # oEmbed responses must be JSON objects.
+        if not isinstance(json_data, dict):
+            raise InvalidResponseException('Response is not a JSON object')
+
         if 'url' not in json_data:
             json_data['url'] = url
         if 'title' not in json_data:

--- a/micawber/tests.py
+++ b/micawber/tests.py
@@ -207,6 +207,21 @@ class ProviderTestCase(BaseTestCase):
         pr.register('http://bad', BadProvider('link'))
         self.assertRaises(InvalidResponseException, pr.request, 'http://bad')
 
+    def test_non_object_json(self):
+        # Non-object JSON must raise InvalidResponseException.
+        bodies = ['[]', 'null', '"url and title"', '123', 'true', 'false']
+        for body in bodies:
+            pr = ProviderRegistry()
+            class BadProvider(Provider):
+                def fetch(self, url, _body=body):
+                    return _body
+            pr.register(r'http://bad\S*', BadProvider('link'))
+            self.assertRaises(InvalidResponseException, pr.request,
+                              'http://bad-test')
+            urls, extracted = pr.extract('see http://bad-test here')
+            self.assertEqual(urls, ['http://bad-test'])
+            self.assertEqual(extracted, {})
+
 
 class EscapingTestCase(BaseTestCase):
     # html-escaped form of the title in the "link-unsafe" test fixture.


### PR DESCRIPTION
Malformed JSON already raises `InvalidResponseException`, but a JSON array, string, null, number, or bool still reached the url assignment and leaked `TypeError`. `extract`/`parse` only catch `ProviderException`, so those responses did not soft-fail.

Raise `InvalidResponseException` when the decoded body is not an object, same as the bad-JSON path.