### PR TITLE
Fall back to link markup when oEmbed html is missing

### DIFF
--- a/micawber/parsers.py
+++ b/micawber/parsers.py
@@ -46,7 +46,10 @@ def full_handler(url, response_data, **params):
     elif response_data['type'] == 'photo':
         return '<a href="%(url)s" title="%(title)s"><img alt="%(title)s" src="%(url)s" /></a>' % _escape_data(response_data)
     else:
-        return response_data['html']
+        html = response_data.get('html')
+        if html is None:
+            return '<a href="%(url)s" title="%(title)s">%(title)s</a>' % _escape_data(response_data)
+        return html
 
 def inline_handler(url, response_data, **params):
     return '<a href="%(url)s" title="%(title)s">%(title)s</a>' % _escape_data(response_data)

--- a/micawber/tests.py
+++ b/micawber/tests.py
@@ -245,6 +245,23 @@ class EscapingTestCase(BaseTestCase):
         self.assertEqual(full_handler('http://video-test1', resp),
                          '<test1>video</test1>')
 
+    def test_full_handler_without_html_falls_back_to_link(self):
+        from micawber.parsers import parse_text_full
+
+        resp = {'type': 'video', 'url': 'http://video-test1', 'title': 'vtest1'}
+        expected = '<a href="http://video-test1" title="vtest1">vtest1</a>'
+        self.assertEqual(full_handler('http://video-test1', resp), expected)
+
+        class NoHtmlVideoProvider(Provider):
+            def request(self, url, **params):
+                return {'type': 'video', 'title': 'broken', 'url': url}
+
+        pr = ProviderRegistry()
+        pr.register(r'http://video-nohtml', NoHtmlVideoProvider('video'))
+        self.assertEqual(
+            parse_text_full('http://video-nohtml/foo', pr),
+            '<a href="http://video-nohtml/foo" title="broken">broken</a>')
+
 
 class PickleCacheTestCase(unittest.TestCase):
     def setUp(self):


### PR DESCRIPTION
`parse_text_full` uses `full_handler` by default. When an oEmbed provider returns type `video` or `rich` without an `html` field, `full_handler` raised `KeyError: 'html'`. `inline_handler` already renders those responses as plain links; `full_handler` now does the same when `html` is absent.