### PR TITLE
Skip oEmbed rewrites inside HTML comments

### DIFF
--- a/micawber/parsers.py
+++ b/micawber/parsers.py
@@ -3,10 +3,11 @@ import re
 from html import escape
 
 try:
-    from bs4 import BeautifulSoup
+    from bs4 import BeautifulSoup, Comment
     bs_kwargs = replace_kwargs = {'features': 'html.parser'}
 except ImportError:
     BeautifulSoup = None
+    Comment = None
     bs_kwargs = replace_kwargs = {}
 
 from micawber.exceptions import ProviderException
@@ -200,6 +201,9 @@ def _is_standalone(soup_elem):
     return False
 
 def _inside_skip(soup_elem):
+    # Comment nodes match url_re as strings; leave them like script/style skips.
+    if Comment is not None and isinstance(soup_elem, Comment):
+        return True
     parent = soup_elem.parent
     while parent is not None:
         if parent.name in skip_elements:

--- a/micawber/tests.py
+++ b/micawber/tests.py
@@ -574,6 +574,16 @@ class ParserTestCase(BaseTestCase):
             html = frame % 'http://link-test1'
             self.assertEqual(test_pr.parse_html(html), html)
 
+    def test_skip_html_comments(self):
+        html = ('<div><!-- keep http://link-test1 --><p>http://link-test1</p>'
+                '</div>')
+        parsed = test_pr.parse_html(html)
+        self.assertIn('<!-- keep http://link-test1 -->', parsed)
+        self.assertIn(self.full_pairs['http://link-test1'], parsed)
+        urls, extracted = test_pr.extract_html(html)
+        self.assertEqual(urls, ['http://link-test1'])
+        self.assertEqual(len(extracted), 1)
+
     def test_urlize_params(self):
         text = 'test http://foo.com/'
         urlize_params = {'target': '_blank', 'rel': 'nofollow'}


### PR DESCRIPTION
`parse_html` matched URLs in BeautifulSoup `Comment` nodes and replaced the whole comment with visible oEmbed markup. Leave comments untouched, matching the existing script/style skip path.